### PR TITLE
Support compile `gix-url` to wasm32-wasi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Install Rust
         run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
-      - run: set +x; for name in gix-actor gix-attributes gix-bitmap gix-chunk gix-command gix-commitgraph gix-config-value gix-date gix-glob gix-hash gix-hashtable gix-mailmap gix-object gix-packetline gix-path gix-pathspec gix-prompt gix-quote gix-refspec gix-revision gix-traverse gix-validate; do (cd $name && cargo build --target ${{ matrix.target }}); done
+      - run: set +x; for name in gix-actor gix-attributes gix-bitmap gix-chunk gix-command gix-commitgraph gix-config-value gix-date gix-glob gix-hash gix-hashtable gix-mailmap gix-object gix-packetline gix-path gix-pathspec gix-prompt gix-quote gix-refspec gix-revision gix-traverse gix-url gix-validate; do (cd $name && cargo build --target ${{ matrix.target }}); done
         name: crates without feature toggles
       - run: set +x; for feature in progress fs-walkdir-parallel parallel io-pipe crc32 zlib zlib-rust-backend fast-sha1 rustsha1 cache-efficiency-debug; do (cd gix-features && cargo build --features $feature --target ${{ matrix.target }}); done
         name: features of gix-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,7 +2689,6 @@ dependencies = [
  "gix-features 0.38.2",
  "gix-path 0.10.10",
  "gix-testtools",
- "home",
  "serde",
  "thiserror",
  "url",

--- a/gix-url/Cargo.toml
+++ b/gix-url/Cargo.toml
@@ -24,7 +24,6 @@ serde = { version = "1.0.114", optional = true, default-features = false, featur
 thiserror = "1.0.32"
 url = "2.5.1"
 bstr = { version = "1.3.0", default-features = false, features = ["std"] }
-home = "0.5.5"
 
 document-features = { version = "0.2.0", optional = true }
 

--- a/gix-url/src/lib.rs
+++ b/gix-url/src/lib.rs
@@ -48,9 +48,9 @@ pub fn parse(input: &BStr) -> Result<Url, parse::Error> {
 /// If more precise control of the resolution mechanism is needed, then use the [expand_path::with()] function.
 pub fn expand_path(user: Option<&expand_path::ForUser>, path: &BStr) -> Result<PathBuf, expand_path::Error> {
     expand_path::with(user, path, |user| match user {
-        expand_path::ForUser::Current => home::home_dir(),
+        expand_path::ForUser::Current => gix_path::env::home_dir(),
         expand_path::ForUser::Name(user) => {
-            home::home_dir().and_then(|home| home.parent().map(|home_dirs| home_dirs.join(user.to_string())))
+            gix_path::env::home_dir().and_then(|home| home.parent().map(|home_dirs| home_dirs.join(user.to_string())))
         }
     })
 }

--- a/gix-validate/src/tag.rs
+++ b/gix-validate/src/tag.rs
@@ -116,13 +116,6 @@ pub(crate) fn name_inner(input: &BStr, mode: Mode) -> Result<Option<BString>, na
                     return Err(name::Error::RepeatedSlash);
                 }
             }
-            b'.' if previous == b'/' => {
-                if let Some(out) = out.as_mut() {
-                    out.push(b'-');
-                } else {
-                    return Err(name::Error::StartsWithDot);
-                }
-            }
             c => {
                 if *c == b'/' {
                     component_start = component_end;


### PR DESCRIPTION
Hi! I tried to compile gix-value-config to wasm32-wasi but encountered an error during compilation with this error:
```
error[E0425]: cannot find function `home_dir_inner` in the crate root
  --> /.cargo/registry/src/index.crates.io-6f17d22bba15001f/home-0.5.9/src/env.rs:33:16
   |
33 |         crate::home_dir_inner()
   |                ^^^^^^^^^^^^^^ not found in the crate root
   |
note: found an item that was configured out
  --> /.cargo/registry/src/index.crates.io-6f17d22bba15001f/home-0.5.9/src/lib.rs:66:14
   |
66 | use windows::home_dir_inner;
   |              ^^^^^^^^^^^^^^
note: found an item that was configured out
  --> /.cargo/registry/src/index.crates.io-6f17d22bba15001f/home-0.5.9/src/lib.rs:69:4
   |
69 | fn home_dir_inner() -> Option<PathBuf> {
   |    ^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0425`.
error: could not compile `home` (lib) due to 1 previous error
```
The reason for this error is that `home` does not support wasm. However, `gix-path`, which `gix-url` depends on, has a function `gix_path::env::home_dir` that provides similar functionality.
So, I used `gix_path::env::home_dir` instead of `home::home_dir` and remove `home` from `gix-url` dependencies.